### PR TITLE
Optimize leaderboard updates

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -27,7 +27,7 @@ func (s *Server) ServeWebsocket(w http.ResponseWriter, r *http.Request) {
 	user, err := s.getOrCreateUser(r, w)
 
 	if err != nil {
-		fmt.Printf("Error retrieving user: %v\n")
+		fmt.Printf("Error retrieving user: %v\n", err)
 		return
 	}
 

--- a/server/notifications.go
+++ b/server/notifications.go
@@ -64,3 +64,8 @@ func leaderboardUpdateNotification(data []db.LeaderboardRowData) ServerMessage {
 
 	return ServerMessage{"leaderboard", string(jsonData)}
 }
+
+func leaderboardDeltaNotification(data []db.LeaderboardRowData) ServerMessage {
+	jsonData, _ := json.Marshal(data)
+	return ServerMessage{"leaderboardDelta", string(jsonData)}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -11,6 +11,7 @@ import (
 type Server struct {
 	store *db.UserStore
 	Game  *game.Service
+	LB    *db.Leaderboard
 
 	Mux   *http.ServeMux
 	WsURL string
@@ -25,9 +26,11 @@ type Server struct {
 }
 
 func NewServer(store *db.UserStore, game *game.Service, url string) *Server {
+	lb := db.NewLeaderboard(store.GetTopPlayers())
 	return &Server{
 		store:      store,
 		Game:       game,
+		LB:         lb,
 		Mux:        http.NewServeMux(),
 		WsURL:      url,
 		in:         make(chan ClientMessage),
@@ -42,7 +45,6 @@ func NewServer(store *db.UserStore, game *game.Service, url string) *Server {
 func (s *Server) Start() {
 	s.InitRoutes()
 	go s.listen()
-	go s.updateLeaderboard()
 	go s.store.Autosave()
 }
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -5,7 +5,6 @@ import (
 	"github.com/nathanmazzapica/pet-daisy/utils"
 	"log"
 	"strconv"
-	"time"
 )
 
 func (s *Server) listen() {
@@ -29,6 +28,11 @@ func (s *Server) handleIncomingMessage(message ClientMessage) {
 
 		s.Game.PetDaisy(message.Client.user)
 
+		diff := s.LB.UpdateUser(message.Client.user)
+		if len(diff) > 0 {
+			s.out <- leaderboardDeltaNotification(diff)
+		}
+
 		s.out <- ServerMessage{
 			Name: "petCounter",
 			Data: strconv.Itoa(int(s.Game.PetCount)),
@@ -48,9 +52,11 @@ func (s *Server) handleIncomingMessage(message ClientMessage) {
 func (s *Server) handleClientRegister(client *Client) {
 	s.clients[client] = true
 
+	// Send the current leaderboard to the new client
+	client.send <- leaderboardUpdateNotification(s.LB.GetAll())
+
 	s.out <- playerJoinNotification(client.DisplayName())
 	s.out <- playerCountNotification(len(s.clients))
-	//	s.out <- leaderboardUpdateNotification(s.store.GetTopPlayers())
 
 	utils.SendPlayerConnectionWebhook(client.DisplayName())
 
@@ -82,13 +88,4 @@ func (s *Server) broadcast() {
 
 // Need to rethink leaderboard networking to find healthy balance between network usage and crisp realtimeness
 // TODO: Send diffs instead of full LB every time
-func (s *Server) updateLeaderboard() {
-	for {
-		time.Sleep(100 * time.Millisecond)
-		// TODO: Implement state to pause leaderboard transmission during bulk save to prevent db lock error
-		// TODO: use redis or build own in-memory leaderboard. Polling from the db directly every time just causes problems and isn't good practice
-		// TODO: stop sending 1kb of data per user every 100ms like cmon BRO THIS IS TRASH MAKE IT NOT
-		// this leaderboard is like 98% of our problems
-		//s.out <- leaderboardUpdateNotification(s.store.GetTopPlayers())
-	}
-}
+// deprecated

--- a/static/scripts/leaderboard.js
+++ b/static/scripts/leaderboard.js
@@ -1,21 +1,24 @@
+let leaderboardData = [];
+
 /**
  * @param {leaderboardData[]} data
  * */
 function displayLeaderboard(data) {
+    leaderboardData = data;
 
     const leaderboard = document.getElementById('leaderboard');
     leaderboard.innerHTML = '';
-    for (let i = 0; i < data.length; i++) {
+    for (let i = 0; i < leaderboardData.length; i++) {
         const row = document.createElement('tr');
         const posCol = document.createElement('td');
         const displayNameCol = document.createElement('td');
         const petsCol = document.createElement('td');
 
-        posCol.innerText = `${Number(data[i].position).toLocaleString()}`;
-        displayNameCol.innerText = `${data[i].display_name}`;
-        petsCol.innerText = `${data[i].pet_count}`;
+        posCol.innerText = `${Number(leaderboardData[i].position).toLocaleString()}`;
+        displayNameCol.innerText = `${leaderboardData[i].display_name}`;
+        petsCol.innerText = `${leaderboardData[i].pet_count}`;
 
-        if (data[i].display_name === displayName) {
+        if (leaderboardData[i].display_name === displayName) {
             row.style.backgroundColor = 'var(--dark-purple-bg)';
         }
 
@@ -25,4 +28,27 @@ function displayLeaderboard(data) {
 
         leaderboard.appendChild(row);
     }
+}
+
+function updateLeaderboardDelta(changes) {
+    for (const change of changes) {
+        if (change.position === 0) {
+            leaderboardData = leaderboardData.filter(r => r.display_name !== change.display_name);
+            continue;
+        }
+
+        const idx = leaderboardData.findIndex(r => r.display_name === change.display_name);
+        if (idx !== -1) {
+            leaderboardData[idx] = change;
+        } else {
+            leaderboardData.push(change);
+        }
+    }
+
+    leaderboardData.sort((a, b) => a.position - b.position);
+    if (leaderboardData.length > 10) {
+        leaderboardData = leaderboardData.slice(0, 10);
+    }
+
+    displayLeaderboard(leaderboardData);
 }

--- a/static/scripts/script.js
+++ b/static/scripts/script.js
@@ -52,6 +52,9 @@ ws.onmessage = (event) => {
         case "leaderboard":
             displayLeaderboard(JSON.parse(message.data));
             break;
+        case "leaderboardDelta":
+            updateLeaderboardDelta(JSON.parse(message.data));
+            break;
         default:
             handleIncomingChat(message.name, message.data)
     }


### PR DESCRIPTION
## Summary
- maintain leaderboard in memory
- broadcast delta rows when a player's score changes
- initialize leaderboard when clients connect
- add client-side logic for incremental leaderboard updates

## Testing
- `go vet ./...` *(fails: User struct with mutex warnings, unreachable code warnings)*
- `go build ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686fd340b3a483238972b38b94f29386